### PR TITLE
Use 32 bits counter instead of 16bits to handle high precision encoder for motor control

### DIFF
--- a/src/encoderR4.cpp
+++ b/src/encoderR4.cpp
@@ -42,7 +42,7 @@ bool EncoderR4::begin()
     ret = ret && hasChannelA && hasChannelB;
 
     _timer.force_use_of_pwm_reserved_timer();
-    ret = ret && _timer.begin(TIMER_MODE_PERIODIC, GPT_TIMER, channel, 0x10000, 0, TIMER_SOURCE_DIV_1);
+	ret = ret && _timer.begin(TIMER_MODE_PERIODIC, GPT_TIMER, channel, 0, 0, TIMER_SOURCE_DIV_1);
     ret = ret && _timer.open();
 
     if(!ret){
@@ -92,15 +92,15 @@ bool EncoderR4::begin()
     return ret;
 }
 
-uint16_t EncoderR4::read()
+uint32_t EncoderR4::read()
 {
     return _timer.get_counter();
 }
 
-int16_t EncoderR4::readChange()
+int32_t EncoderR4::readChange()
 {
-    auto v = read();
-    int16_t ret = v - _lastValue;
+    uint32_t v = read();
+    int32_t ret = v - _lastValue;
     _lastValue = v;
 
     return ret;

--- a/src/encoderR4.h
+++ b/src/encoderR4.h
@@ -8,13 +8,13 @@ class EncoderR4{
         EncoderR4(unsigned int pinA, unsigned int pinB);
 
         bool begin();
-        uint16_t read();
-        int16_t readChange();
+        uint32_t read();
+        int32_t readChange();
     private:
         unsigned int _pinA;
         unsigned int _pinB;
         FspTimer _timer{};
-        uint16_t _lastValue;
+        uint32_t _lastValue;
 };
 
 #endif // _ENCODERR4_H_


### PR DESCRIPTION
Since the internal GPT module can work in 32 bits mode, limiting the encoder module to 16bits is not a hardware limitation.
The 16bits value can easily be computed using a cast to uint16_t, or a mask operation on the 16bits LSB (0xFFFF).